### PR TITLE
Problem: README does not reflect the latest Cronos rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and the [contributing guidelines](CONTRIBUTING.md) when submitting code.
 
 ## 4. Documentation
 
-[Technical documentation](http://cronos.crypto.org/docs).
+[Technical documentation](http://cronos.org/docs).
 
 <a id="build" />
 
@@ -72,13 +72,13 @@ make build
 
 ## 6. Start a local Development Network and Node
 
-Please follow this [documentation](https://cronos.crypto.org/docs/getting-started/local-devnet.html#devnet-running-latest-development-node) to run a local devnet.
+Please follow this [documentation](https://cronos.org/docs/getting-started/local-devnet.html#devnet-running-latest-development-node) to run a local devnet.
 
 <a id="send-first-transaction" />
 
 ## 7. Send Your First Transaction
 
-After setting the local devnet, you may interact with the your local blockchain by following this [documentation](https://cronos.crypto.org/docs/getting-started/local-devnet.html#interact-with-the-chain).
+After setting the local devnet, you may interact with the your local blockchain by following this [documentation](https://cronos.org/docs/getting-started/local-devnet.html#interact-with-the-chain).
 
 <a id="testing" />
 
@@ -149,8 +149,8 @@ pystarport supervisorctl stop all
 
 ## 10. Useful links
 
-- [Project Website](http://cronos.crypto.org/)
-- [Technical Documentation](http://cronos.crypto.org/docs)
+- [Project Website](http://cronos.org/)
+- [Technical Documentation](http://cronos.org/docs)
 - Community chatrooms (non-technical): [Discord](https://discord.gg/nsp9JTC) [Telegram](https://t.me/CryptoComOfficial)
 - Developer community channel (technical): [![Support Server](https://img.shields.io/discord/783264383978569728.svg?color=7289da&label=Crypto.org Chain =discord =flat-square)](https://discord.gg/pahqHz26q4)
 - [Ethermint](https://github.com/tharsis/ethermint) by Tharsis


### PR DESCRIPTION
Solution: Update links to the new cronos.org
